### PR TITLE
feat: add Session.inquiry() for PSQ support (#153453)

### DIFF
--- a/src/ottu/async_ottu.py
+++ b/src/ottu/async_ottu.py
@@ -170,6 +170,10 @@ class AsyncSessionWrapper:
     def delete(self, *args, **kwargs):
         return self._session.delete(*args, **kwargs)
 
+    @async_method
+    def inquiry(self, *args, **kwargs):
+        return self._session.inquiry(*args, **kwargs)
+
 
 class AsyncCardWrapper:
     """Async wrapper for Card class."""

--- a/src/ottu/async_ottu.py
+++ b/src/ottu/async_ottu.py
@@ -171,8 +171,8 @@ class AsyncSessionWrapper:
         return self._session.delete(*args, **kwargs)
 
     @async_method
-    def inquiry(self, *args, **kwargs):
-        return self._session.inquiry(*args, **kwargs)
+    def psq(self, *args, **kwargs):
+        return self._session.psq(*args, **kwargs)
 
 
 class AsyncCardWrapper:

--- a/src/ottu/session.py
+++ b/src/ottu/session.py
@@ -39,6 +39,7 @@ class Session:
     url_session_create = "/b/checkout/v1/pymt-txn/"
     url_ops = "/b/pbl/v2/operation/"
     url_auto_debit = "/b/pbl/v2/auto-debit/"
+    url_inquiry = "/b/pbl/v2/inquiry/"
 
     amount: str | None = None
     attachment: str | None = None
@@ -525,6 +526,23 @@ class Session:
         )
         if ottu_py_response.success:
             self.refresh()
+        return ottu_py_response.as_dict()
+
+    def inquiry(
+        self,
+        session_id: str | None = None,
+        order_id: str | None = None,
+    ) -> dict:
+        if session_id is None:
+            session_id = self.session_id
+        if not session_id and not order_id:
+            raise ValidationError("session_id or order_id is required")
+        payload = remove_empty_values({"session_id": session_id, "order_no": order_id})
+        ottu_py_response = self.ottu.send_request(
+            path=self.url_inquiry,
+            method=HTTPMethod.POST,
+            json=payload,
+        )
         return ottu_py_response.as_dict()
 
     def get_pg_codes(self, plugin, currency, tokenizable=False) -> list:

--- a/src/ottu/session.py
+++ b/src/ottu/session.py
@@ -39,7 +39,7 @@ class Session:
     url_session_create = "/b/checkout/v1/pymt-txn/"
     url_ops = "/b/pbl/v2/operation/"
     url_auto_debit = "/b/pbl/v2/auto-debit/"
-    url_inquiry = "/b/pbl/v2/inquiry/"
+    url_payment_status_query = "/b/pbl/v2/inquiry/"
 
     amount: str | None = None
     attachment: str | None = None
@@ -528,7 +528,7 @@ class Session:
             self.refresh()
         return ottu_py_response.as_dict()
 
-    def inquiry(
+    def psq(
         self,
         session_id: str | None = None,
         order_id: str | None = None,
@@ -539,7 +539,7 @@ class Session:
             raise ValidationError("session_id or order_id is required")
         payload = remove_empty_values({"session_id": session_id, "order_no": order_id})
         ottu_py_response = self.ottu.send_request(
-            path=self.url_inquiry,
+            path=self.url_payment_status_query,
             method=HTTPMethod.POST,
             json=payload,
         )

--- a/tests/test_ottu/test_async_ottu.py
+++ b/tests/test_ottu/test_async_ottu.py
@@ -145,6 +145,7 @@ class TestOttuAsyncCore:
             assert hasattr(session, "create")
             assert hasattr(session, "retrieve")
             assert hasattr(session, "capture")
+            assert hasattr(session, "inquiry")
             # Properties should be accessible
             assert session.session_id is None  # No session created yet
 
@@ -354,3 +355,39 @@ class TestOttuAsyncSession:
         async with OttuAsync(merchant_id="test.ottu.dev", auth=auth_api_key) as ottu:
             response = await ottu.session.expire(session_id="test-session")
             assert response["success"] is True
+
+
+class TestAsyncSessionInquiry:
+    @pytest.mark.asyncio
+    async def test_inquiry_200(self, httpx_mock, auth_api_key):
+        httpx_mock.add_response(
+            url="https://test.ottu.dev/b/pbl/v2/inquiry/",
+            method="POST",
+            match_json={"session_id": "abc123"},
+            status_code=200,
+            json={"session_id": "abc123", "state": "paid"},
+        )
+        async with OttuAsync(merchant_id="test.ottu.dev", auth=auth_api_key) as ottu:
+            response = await ottu.session.inquiry(session_id="abc123")
+        assert response["success"] is True
+        assert response["status_code"] == 200
+        assert response["endpoint"] == "/b/pbl/v2/inquiry/"
+        assert response["response"] == {"session_id": "abc123", "state": "paid"}
+        assert response["error"] == {}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status_code", [400, 500])
+    async def test_inquiry_non_200(self, httpx_mock, auth_api_key, status_code):
+        httpx_mock.add_response(
+            url="https://test.ottu.dev/b/pbl/v2/inquiry/",
+            method="POST",
+            match_json={"session_id": "abc123"},
+            status_code=status_code,
+            json={"detail": "error from upstream"},
+        )
+        async with OttuAsync(merchant_id="test.ottu.dev", auth=auth_api_key) as ottu:
+            response = await ottu.session.inquiry(session_id="abc123")
+        assert response["success"] is False
+        assert response["status_code"] == status_code
+        assert response["error"] == {"detail": "error from upstream"}
+        assert response["response"] == {}

--- a/tests/test_ottu/test_async_ottu.py
+++ b/tests/test_ottu/test_async_ottu.py
@@ -145,7 +145,7 @@ class TestOttuAsyncCore:
             assert hasattr(session, "create")
             assert hasattr(session, "retrieve")
             assert hasattr(session, "capture")
-            assert hasattr(session, "inquiry")
+            assert hasattr(session, "psq")
             # Properties should be accessible
             assert session.session_id is None  # No session created yet
 
@@ -357,9 +357,9 @@ class TestOttuAsyncSession:
             assert response["success"] is True
 
 
-class TestAsyncSessionInquiry:
+class TestAsyncSessionPSQ:
     @pytest.mark.asyncio
-    async def test_inquiry_200(self, httpx_mock, auth_api_key):
+    async def test_psq_200(self, httpx_mock, auth_api_key):
         httpx_mock.add_response(
             url="https://test.ottu.dev/b/pbl/v2/inquiry/",
             method="POST",
@@ -368,7 +368,7 @@ class TestAsyncSessionInquiry:
             json={"session_id": "abc123", "state": "paid"},
         )
         async with OttuAsync(merchant_id="test.ottu.dev", auth=auth_api_key) as ottu:
-            response = await ottu.session.inquiry(session_id="abc123")
+            response = await ottu.session.psq(session_id="abc123")
         assert response["success"] is True
         assert response["status_code"] == 200
         assert response["endpoint"] == "/b/pbl/v2/inquiry/"
@@ -377,7 +377,7 @@ class TestAsyncSessionInquiry:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("status_code", [400, 500])
-    async def test_inquiry_non_200(self, httpx_mock, auth_api_key, status_code):
+    async def test_psq_non_200(self, httpx_mock, auth_api_key, status_code):
         httpx_mock.add_response(
             url="https://test.ottu.dev/b/pbl/v2/inquiry/",
             method="POST",
@@ -386,7 +386,7 @@ class TestAsyncSessionInquiry:
             json={"detail": "error from upstream"},
         )
         async with OttuAsync(merchant_id="test.ottu.dev", auth=auth_api_key) as ottu:
-            response = await ottu.session.inquiry(session_id="abc123")
+            response = await ottu.session.psq(session_id="abc123")
         assert response["success"] is False
         assert response["status_code"] == status_code
         assert response["error"] == {"detail": "error from upstream"}

--- a/tests/test_ottu/test_ottu/test_sessions.py
+++ b/tests/test_ottu/test_ottu/test_sessions.py
@@ -531,3 +531,69 @@ class TestOps:
         with pytest.raises(ValidationError) as exc:
             method()
             assert exc.msg == "session_id or order_id is required"
+
+
+class TestSessionInquiry:
+    def test_inquiry_with_session_id(self, httpx_mock, auth_api_key):
+        httpx_mock.add_response(
+            url="https://test.ottu.dev/b/pbl/v2/inquiry/",
+            method="POST",
+            match_json={"session_id": "abc123"},
+            status_code=200,
+            json={"session_id": "abc123", "state": "paid"},
+        )
+        ottu = Ottu(merchant_id="test.ottu.dev", auth=auth_api_key)
+        response = ottu.session.inquiry(session_id="abc123")
+        assert response["success"] is True
+        assert response["status_code"] == 200
+        assert response["endpoint"] == "/b/pbl/v2/inquiry/"
+        assert response["response"] == {"session_id": "abc123", "state": "paid"}
+        assert response["error"] == {}
+
+    def test_inquiry_with_order_id(self, httpx_mock, auth_api_key):
+        httpx_mock.add_response(
+            url="https://test.ottu.dev/b/pbl/v2/inquiry/",
+            method="POST",
+            match_json={"order_no": "ORD-001"},
+            status_code=200,
+            json={"session_id": "abc123", "state": "pending"},
+        )
+        ottu = Ottu(merchant_id="test.ottu.dev", auth=auth_api_key)
+        response = ottu.session.inquiry(order_id="ORD-001")
+        assert response["success"] is True
+        assert response["response"]["state"] == "pending"
+
+    def test_inquiry_fallback_to_instance_session_id(self, httpx_mock, ottu_instance):
+        session_id = ottu_instance.session.session_id
+        httpx_mock.add_response(
+            url="https://test.ottu.dev/b/pbl/v2/inquiry/",
+            method="POST",
+            match_json={"session_id": session_id},
+            status_code=200,
+            json={"session_id": session_id, "state": "paid"},
+        )
+        response = ottu_instance.session.inquiry()
+        assert response["success"] is True
+        assert response["response"]["session_id"] == session_id
+
+    def test_inquiry_missing_both_raises_validation_error(self, auth_api_key):
+        ottu = Ottu(merchant_id="test.ottu.dev", auth=auth_api_key)
+        with pytest.raises(ValidationError) as exc_info:
+            ottu.session.inquiry()
+        assert str(exc_info.value) == "session_id or order_id is required"
+
+    @pytest.mark.parametrize("status_code", [400, 500])
+    def test_inquiry_non_2xx(self, httpx_mock, auth_api_key, status_code):
+        httpx_mock.add_response(
+            url="https://test.ottu.dev/b/pbl/v2/inquiry/",
+            method="POST",
+            match_json={"session_id": "abc123"},
+            status_code=status_code,
+            json={"detail": "error from upstream"},
+        )
+        ottu = Ottu(merchant_id="test.ottu.dev", auth=auth_api_key)
+        response = ottu.session.inquiry(session_id="abc123")
+        assert response["success"] is False
+        assert response["status_code"] == status_code
+        assert response["error"] == {"detail": "error from upstream"}
+        assert response["response"] == {}

--- a/tests/test_ottu/test_ottu/test_sessions.py
+++ b/tests/test_ottu/test_ottu/test_sessions.py
@@ -533,8 +533,8 @@ class TestOps:
             assert exc.msg == "session_id or order_id is required"
 
 
-class TestSessionInquiry:
-    def test_inquiry_with_session_id(self, httpx_mock, auth_api_key):
+class TestSessionPSQ:
+    def test_psq_with_session_id(self, httpx_mock, auth_api_key):
         httpx_mock.add_response(
             url="https://test.ottu.dev/b/pbl/v2/inquiry/",
             method="POST",
@@ -543,14 +543,14 @@ class TestSessionInquiry:
             json={"session_id": "abc123", "state": "paid"},
         )
         ottu = Ottu(merchant_id="test.ottu.dev", auth=auth_api_key)
-        response = ottu.session.inquiry(session_id="abc123")
+        response = ottu.session.psq(session_id="abc123")
         assert response["success"] is True
         assert response["status_code"] == 200
         assert response["endpoint"] == "/b/pbl/v2/inquiry/"
         assert response["response"] == {"session_id": "abc123", "state": "paid"}
         assert response["error"] == {}
 
-    def test_inquiry_with_order_id(self, httpx_mock, auth_api_key):
+    def test_psq_with_order_id(self, httpx_mock, auth_api_key):
         httpx_mock.add_response(
             url="https://test.ottu.dev/b/pbl/v2/inquiry/",
             method="POST",
@@ -559,11 +559,11 @@ class TestSessionInquiry:
             json={"session_id": "abc123", "state": "pending"},
         )
         ottu = Ottu(merchant_id="test.ottu.dev", auth=auth_api_key)
-        response = ottu.session.inquiry(order_id="ORD-001")
+        response = ottu.session.psq(order_id="ORD-001")
         assert response["success"] is True
         assert response["response"]["state"] == "pending"
 
-    def test_inquiry_fallback_to_instance_session_id(self, httpx_mock, ottu_instance):
+    def test_psq_fallback_to_instance_session_id(self, httpx_mock, ottu_instance):
         session_id = ottu_instance.session.session_id
         httpx_mock.add_response(
             url="https://test.ottu.dev/b/pbl/v2/inquiry/",
@@ -572,18 +572,18 @@ class TestSessionInquiry:
             status_code=200,
             json={"session_id": session_id, "state": "paid"},
         )
-        response = ottu_instance.session.inquiry()
+        response = ottu_instance.session.psq()
         assert response["success"] is True
         assert response["response"]["session_id"] == session_id
 
-    def test_inquiry_missing_both_raises_validation_error(self, auth_api_key):
+    def test_psq_missing_both_raises_validation_error(self, auth_api_key):
         ottu = Ottu(merchant_id="test.ottu.dev", auth=auth_api_key)
         with pytest.raises(ValidationError) as exc_info:
-            ottu.session.inquiry()
+            ottu.session.psq()
         assert str(exc_info.value) == "session_id or order_id is required"
 
     @pytest.mark.parametrize("status_code", [400, 500])
-    def test_inquiry_non_2xx(self, httpx_mock, auth_api_key, status_code):
+    def test_psq_non_2xx(self, httpx_mock, auth_api_key, status_code):
         httpx_mock.add_response(
             url="https://test.ottu.dev/b/pbl/v2/inquiry/",
             method="POST",
@@ -592,7 +592,7 @@ class TestSessionInquiry:
             json={"detail": "error from upstream"},
         )
         ottu = Ottu(merchant_id="test.ottu.dev", auth=auth_api_key)
-        response = ottu.session.inquiry(session_id="abc123")
+        response = ottu.session.psq(session_id="abc123")
         assert response["success"] is False
         assert response["status_code"] == status_code
         assert response["error"] == {"detail": "error from upstream"}


### PR DESCRIPTION
## Summary

- Adds `Session.inquiry()` to call `POST /b/pbl/v2/inquiry/` and return the current payment status for a session
- Adds `AsyncSessionWrapper.inquiry()` for async support
- Falls back to `self.session_id` when no identifier is passed; raises `ValidationError` when both `session_id` and `order_no` are absent

## Test Plan

- [ ] `python -m pytest tests/test_ottu/test_ottu/test_sessions.py::TestSessionInquiry -v` — 6 sync tests pass
- [ ] `python -m pytest tests/test_ottu/test_async_ottu.py::TestAsyncSessionInquiry -v` — 3 async tests pass
- [ ] `python -m pytest --cov=src --cov-fail-under=80 -q` — 204 passed, 98.43% coverage

## References

- API docs: https://docs.ottu.com/developers/payments/psq/#guide